### PR TITLE
Request Data Stream

### DIFF
--- a/acomm/README.md
+++ b/acomm/README.md
@@ -278,12 +278,14 @@ socket.
 ```go
 func (t *Tracker) ProxyUnix(req *Request, timeout time.Duration) (*Request, error)
 ```
-ProxyUnix proxies requests that have response hooks of non-unix sockets through
-one that does. If the response hook is already a unix socket, it returns the
-original request. If not, it tracks the original request and returns a new
-request with a unix socket response hook. The purpose of this is so that there
-can be a single entry and exit point for external communication, while local
-services can reply directly to each other.
+ProxyUnix proxies requests that have response hooks and stream urls of non-unix
+sockets. If the response hook and stream url are already unix sockets, it
+returns the original request. If the response hook is not, it tracks the
+original request and returns a new request with a unix socket response hook. If
+the stream url is not, it pipes the original stream through a new unix socket
+and updates the stream url. The purpose of this is so that there can be a single
+entry and exit point for external communication, while local services can reply
+directly to each other.
 
 #### func (*Tracker) RemoveRequest
 

--- a/acomm/README.md
+++ b/acomm/README.md
@@ -118,6 +118,7 @@ type Request struct {
 	ID             string           `json:"id"`
 	Task           string           `json:"task"`
 	ResponseHook   *url.URL         `json:"responsehook"`
+	StreamURL      *url.URL         `json:"stream_url"`
 	Args           *json.RawMessage `json:"args"`
 	SuccessHandler ResponseHandler  `json:"-"`
 	ErrorHandler   ResponseHandler  `json:"-"`
@@ -132,7 +133,7 @@ appropriately to handle a response.
 #### func  NewRequest
 
 ```go
-func NewRequest(task, responseHook string, args interface{}, sh ResponseHandler, eh ResponseHandler) (*Request, error)
+func NewRequest(task, responseHook, streamURL string, args interface{}, sh ResponseHandler, eh ResponseHandler) (*Request, error)
 ```
 NewRequest creates a new Request instance.
 

--- a/acomm/response_test.go
+++ b/acomm/response_test.go
@@ -41,7 +41,7 @@ func (s *ResponseTestSuite) TestNewResponse() {
 		"foo": "bar",
 	}
 
-	request, _ := acomm.NewRequest("foobar", "unix://foo", nil, nil, nil)
+	request, _ := acomm.NewRequest("foobar", "unix://foo", "", nil, nil, nil)
 	respErr := errors.New("foobar")
 
 	tests := []struct {

--- a/acomm/tracker.go
+++ b/acomm/tracker.go
@@ -3,6 +3,7 @@ package acomm
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -303,11 +304,13 @@ func (t *Tracker) setRequestTimeout(req *Request, timeout time.Duration) {
 	return
 }
 
-// ProxyUnix proxies requests that have response hooks of non-unix sockets
-// through one that does. If the response hook is already a unix socket, it
-// returns the original request. If not, it tracks the original request and
-// returns a new request with a unix socket response hook. The purpose of this
-// is so that there can be a single entry and exit point for external
+// ProxyUnix proxies requests that have response hooks and stream urls of
+// non-unix sockets. If the response hook and stream url are already unix
+// sockets, it returns the original request. If the response hook is not, it
+// tracks the original request and returns a new request with a unix socket
+// response hook. If the stream url is not, it pipes the original stream
+// through a new unix socket and updates the stream url. The purpose of this is
+// so that there can be a single entry and exit point for external
 // communication, while local services can reply directly to each other.
 func (t *Tracker) ProxyUnix(req *Request, timeout time.Duration) (*Request, error) {
 	if t.responseListener == nil {
@@ -318,13 +321,40 @@ func (t *Tracker) ProxyUnix(req *Request, timeout time.Duration) (*Request, erro
 		return nil, err
 	}
 
-	unixReq := req
+	// proxy the stream
+	if req.StreamURL != nil && req.StreamURL.Scheme != "unix" {
+		reader, writer := io.Pipe()
 
+		go func(src *url.URL) {
+			defer func() {
+				if err := writer.Close(); err != nil {
+					log.WithField("error", err).Error("failed to close proxy stream writer")
+				}
+			}()
+			if err := Stream(writer, src); err != nil {
+				log.WithFields(log.Fields{
+					"error":     err,
+					"streamURL": src,
+				}).Error("failed to stream")
+			}
+		}(req.StreamURL)
+
+		addr, err := t.NewStreamUnix("", reader)
+		if err != nil {
+			return nil, err
+		}
+
+		req.StreamURL = addr
+	}
+
+	// proxy the request
+	unixReq := req
 	if req.ResponseHook.Scheme != "unix" {
 		unixReq = &Request{
 			ID:           req.ID,
 			Task:         req.Task,
 			ResponseHook: t.responseListener.URL(),
+			StreamURL:    req.StreamURL,
 			Args:         req.Args,
 			// Success and ErrorHandler are unnecessary here and intentionally
 			// omitted.

--- a/acomm/tracker_test.go
+++ b/acomm/tracker_test.go
@@ -43,7 +43,7 @@ func (s *TrackerTestSuite) SetupSuite() {
 func (s *TrackerTestSuite) SetupTest() {
 	var err error
 
-	s.Request, err = acomm.NewRequest("foobar", s.RespServer.URL, nil, nil, nil)
+	s.Request, err = acomm.NewRequest("foobar", s.RespServer.URL, "", nil, nil, nil)
 	s.Require().NoError(err, "request should be valid")
 
 	streamAddr, _ := url.ParseRequestURI(s.StreamServer.URL)
@@ -134,7 +134,7 @@ func (s *TrackerTestSuite) TestProxyUnix() {
 	s.Equal(0, s.Tracker.NumRequests(), "should have removed the request from tracking")
 
 	// Should not proxy a request already using unix response hook
-	origUnixReq, err := acomm.NewRequest("foobar", "unix://foo", struct{}{}, nil, nil)
+	origUnixReq, err := acomm.NewRequest("foobar", "unix://foo", "", struct{}{}, nil, nil)
 	if !s.NoError(err, "new request shoudl not error") {
 		return
 	}

--- a/acomm/tracker_test.go
+++ b/acomm/tracker_test.go
@@ -1,7 +1,9 @@
 package acomm_test
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -112,12 +114,25 @@ func (s *TrackerTestSuite) TestProxyUnix() {
 		return
 	}
 
-	unixReq, err = s.Tracker.ProxyUnix(s.Request, 0)
+	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "hello")
+	}))
+	defer streamServer.Close()
+
+	req, err := acomm.NewRequest("foobar", s.RespServer.URL, streamServer.URL, nil, nil, nil)
+	s.NoError(err)
+
+	unixReq, err = s.Tracker.ProxyUnix(req, 0)
 	s.NoError(err, "should not fail proxying when tracker is listening")
 	s.NotNil(unixReq, "should return a request")
-	s.Equal(s.Request.ID, unixReq.ID, "new request should share ID with original")
+	s.Equal(req.ID, unixReq.ID, "new request should share ID with original")
 	s.Equal("unix", unixReq.ResponseHook.Scheme, "new request should have a unix response hook")
 	s.Equal(1, s.Tracker.NumRequests(), "should have tracked the new request")
+
+	var reqStreamData bytes.Buffer
+	s.NoError(acomm.Stream(&reqStreamData, unixReq.StreamURL), "should have streamed req data")
+	s.Equal("hello", reqStreamData.String(), "should have streamed req data")
+
 	resp, err := acomm.NewResponse(unixReq, struct{}{}, nil, nil)
 	if !s.NoError(err, "new response should not error") {
 		return

--- a/coordinator/cmd/coordinator-cli/main.go
+++ b/coordinator/cmd/coordinator-cli/main.go
@@ -139,7 +139,7 @@ func makeRequest(coordinator, taskName, responseAddr string, taskArgs map[string
 	}
 
 	responseHook := fmt.Sprintf("http://%s/", responseAddr)
-	req, err := acomm.NewRequest(taskName, responseHook, taskArgs, nil, nil)
+	req, err := acomm.NewRequest(taskName, responseHook, "", taskArgs, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/coordinator/server_test.go
+++ b/coordinator/server_test.go
@@ -139,7 +139,7 @@ func (s *ServerSuite) TestReqRespHandle() {
 			coordinatorURL = internalURL
 		}
 
-		req, _ := acomm.NewRequest(test.taskName, hookURL, test.params, nil, nil)
+		req, _ := acomm.NewRequest(test.taskName, hookURL, "", test.params, nil, nil)
 		if err := acomm.Send(coordinatorURL, req); err != nil {
 			result <- nil
 		}

--- a/provider/examples/simple/simple.go
+++ b/provider/examples/simple/simple.go
@@ -100,11 +100,11 @@ func (s *Simple) SystemStatus(req *acomm.Request) (interface{}, *url.URL, error)
 	// Prepare multiple requests
 	multiRequest := acomm.NewMultiRequest(s.tracker, 0)
 
-	cpuReq, err := acomm.NewRequest("CPUInfo", s.tracker.URL().String(), &CPUInfoArgs{GuestID: args.GuestID}, nil, nil)
+	cpuReq, err := acomm.NewRequest("CPUInfo", s.tracker.URL().String(), "", &CPUInfoArgs{GuestID: args.GuestID}, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}
-	diskReq, err := acomm.NewRequest("DiskInfo", s.tracker.URL().String(), &DiskInfoArgs{GuestID: args.GuestID}, nil, nil)
+	diskReq, err := acomm.NewRequest("DiskInfo", s.tracker.URL().String(), "", &DiskInfoArgs{GuestID: args.GuestID}, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/provider/server_test.go
+++ b/provider/server_test.go
@@ -110,7 +110,7 @@ func (s *ServerSuite) TestStartHandleStop() {
 	respHandler := func(req *acomm.Request, resp *acomm.Response) {
 		close(handled)
 	}
-	req, _ := acomm.NewRequest("foobar", tracker.URL().String(), struct{}{}, respHandler, respHandler)
+	req, _ := acomm.NewRequest("foobar", tracker.URL().String(), "", struct{}{}, respHandler, respHandler)
 	providerSocket, _ := url.ParseRequestURI("unix://" + s.server.TaskSocketPath("foobar"))
 	if !s.NoError(s.server.Tracker().TrackRequest(req, 5*time.Second)) {
 		return


### PR DESCRIPTION
Resolves #47

Allows for streaming of data on requests. The `ProxyUnix` method now also proxies StreamURL when present.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify/49)

<!-- Reviewable:end -->
